### PR TITLE
🏗️ Added functionality to run demo-jvm with knit as a local plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build
 local.properties
 .kotlin
 */bin/*
+.vscode

--- a/demo-jvm/README.md
+++ b/demo-jvm/README.md
@@ -1,0 +1,67 @@
+# demo-jvm: Knit demo (shadow fat jar)
+
+This demo shows Knit bytecode injection on a plain JVM app. It builds a shadow (fat) JAR and runs it.
+
+## Prerequisites
+
+- JDK 11 or newer (tested with Temurin 21 on macOS)
+- Gradle (wrapper included)
+
+Check your Java:
+
+```bash
+java -version
+```
+
+Optionally set JAVA_HOME (zsh):
+
+```bash
+export JAVA_HOME=$(/usr/libexec/java_home)
+```
+
+## One-time setup (local plugin)
+
+This repo applies the Knit Gradle plugin via the plugins DSL and resolves it from a local file repository.
+Publish the plugin to the local repo once before building the demo:
+
+```bash
+./gradlew :knit-plugin:publishAllPublicationsToProjectLocalRepository -x test
+```
+
+Notes:
+
+- No signing is required for the local file-based repository.
+- If/when the plugin is available on Maven Central for the used version, you can skip this step.
+
+## Build the fat jar with Knit
+
+Build the original shadow jar and then transform it with Knit into a new fat jar:
+
+```bash
+./gradlew :demo-jvm:clean :demo-jvm:shadowJarWithKnit
+```
+
+Artifacts:
+
+- Original shadow JAR: `demo-jvm/build/libs/demo-jvm-all.jar`
+- Transformed shadow JAR: `demo-jvm/build/libs/demo-jvm-allWithKnit.jar`
+
+## Run
+
+Run the transformed fat jar:
+
+```bash
+java -jar demo-jvm/build/libs/demo-jvm-allWithKnit.jar
+```
+
+Expected output:
+
+```
+Hello Knit!
+```
+
+## Troubleshooting
+
+- VerifyError about stack map frames: rebuild with `shadowJarWithKnit` after publishing the plugin locally.
+- “Cannot use project dependencies in a script classpath definition”: don’t add `project(":knit-plugin")` in `buildscript`; this demo uses the plugins DSL and the local file repo configured in `settings.gradle.kts`.
+- JDK mismatch: ensure `java -version` shows JDK 11+ (Temurin 21 works).

--- a/demo-jvm/build.gradle.kts
+++ b/demo-jvm/build.gradle.kts
@@ -1,21 +1,9 @@
-buildscript {
-    repositories {
-        mavenLocal()
-        mavenCentral()
-    }
-    val remoteKnitVersion: String by project
-    dependencies {
-        classpath("io.github.tiktok.knit:knit-plugin:$remoteKnitVersion")
-    }
-}
-
 plugins {
     kotlin("jvm")
     id("com.gradleup.shadow") version "8.3.6"
+    id("io.github.tiktok.knit.plugin") version "0.1.5"
     application
 }
-
-apply(plugin = "io.github.tiktok.knit.plugin")
 
 repositories {
     mavenCentral()

--- a/knit-plugin/build.gradle.kts
+++ b/knit-plugin/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     kotlin("jvm")
     id("com.gradle.plugin-publish") version "1.1.0"
     id("insidePublish")
+    id("signing")
 }
 
 val projectGitUrl: String by project
@@ -31,4 +32,8 @@ dependencies {
     compileOnly("com.android.tools.build:gradle:$agpVersion")
     implementation(project(":knit-asm"))
     implementation("org.ow2.asm:asm-tree:$asmVersion")
+}
+
+signing {
+    isRequired = false
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,6 @@
 pluginManagement {
     repositories {
+    maven { url = uri("${rootDir}/build/artifactLocalPublish") }
         mavenLocal()
         mavenCentral()
         gradlePluginPortal()


### PR DESCRIPTION
This pull request introduces a new demo project for using the Knit plugin on a plain JVM application, improves the plugin's usability for local development, and enhances bytecode transformation reliability. The main changes are the addition of the `demo-jvm` demo with clear setup instructions, improved local plugin publishing support, and a fix to ensure valid stack map frames during bytecode injection.

**Demo project and documentation:**

* Added a new `demo-jvm` project with a comprehensive `README.md` explaining prerequisites, local plugin publishing, building, running, and troubleshooting the demo for using Knit with a shadow (fat) JAR.

**Plugin usability and configuration:**

* Updated `demo-jvm/build.gradle.kts` to use the plugins DSL for applying the Knit plugin and removed the legacy `buildscript` block, streamlining plugin configuration.
* Modified `settings.gradle.kts` to add a local file-based repository for plugin resolution, supporting local development and testing of the plugin.
* In `knit-plugin/build.gradle.kts`, added the `signing` plugin and explicitly disabled signing requirements for local publishing, simplifying local builds. [[1]](diffhunk://#diff-be0c90bbffa075271d9bbe66d0467881e8ca1fbd6eda8c6c0893797cdfcb723eR5) [[2]](diffhunk://#diff-be0c90bbffa075271d9bbe66d0467881e8ca1fbd6eda8c6c0893797cdfcb723eR36-R39)

**Bytecode transformation reliability:**

* Updated the `KnitTask` in `knit-plugin` to ensure stack map frames are recomputed after bytecode injection, improving compatibility and preventing `VerifyError`s when running transformed JARs.