### PR TITLE
Added Dump extension to demo-jvm 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build
 local.properties
 .kotlin
 */bin/*
+.vscode

--- a/demo-jvm/README.md
+++ b/demo-jvm/README.md
@@ -1,0 +1,67 @@
+# demo-jvm: Knit demo (shadow fat jar)
+
+This demo shows Knit bytecode injection on a plain JVM app. It builds a shadow (fat) JAR and runs it.
+
+## Prerequisites
+
+- JDK 11 or newer (tested with Temurin 21 on macOS)
+- Gradle (wrapper included)
+
+Check your Java:
+
+```bash
+java -version
+```
+
+Optionally set JAVA_HOME (zsh):
+
+```bash
+export JAVA_HOME=$(/usr/libexec/java_home)
+```
+
+## One-time setup (local plugin)
+
+This repo applies the Knit Gradle plugin via the plugins DSL and resolves it from a local file repository.
+Publish the plugin to the local repo once before building the demo:
+
+```bash
+./gradlew :knit-plugin:publishAllPublicationsToProjectLocalRepository -x test
+```
+
+Notes:
+
+- No signing is required for the local file-based repository.
+- If/when the plugin is available on Maven Central for the used version, you can skip this step.
+
+## Build the fat jar with Knit
+
+Build the original shadow jar and then transform it with Knit into a new fat jar:
+
+```bash
+./gradlew :demo-jvm:clean :demo-jvm:shadowJarWithKnit
+```
+
+Artifacts:
+
+- Original shadow JAR: `demo-jvm/build/libs/demo-jvm-all.jar`
+- Transformed shadow JAR: `demo-jvm/build/libs/demo-jvm-allWithKnit.jar`
+
+## Run
+
+Run the transformed fat jar:
+
+```bash
+java -jar demo-jvm/build/libs/demo-jvm-allWithKnit.jar
+```
+
+Expected output:
+
+```
+Hello Knit!
+```
+
+## Troubleshooting
+
+- VerifyError about stack map frames: rebuild with `shadowJarWithKnit` after publishing the plugin locally.
+- “Cannot use project dependencies in a script classpath definition”: don’t add `project(":knit-plugin")` in `buildscript`; this demo uses the plugins DSL and the local file repo configured in `settings.gradle.kts`.
+- JDK mismatch: ensure `java -version` shows JDK 11+ (Temurin 21 works).

--- a/demo-jvm/build.gradle.kts
+++ b/demo-jvm/build.gradle.kts
@@ -1,21 +1,9 @@
-buildscript {
-    repositories {
-        mavenLocal()
-        mavenCentral()
-    }
-    val remoteKnitVersion: String by project
-    dependencies {
-        classpath("io.github.tiktok.knit:knit-plugin:$remoteKnitVersion")
-    }
-}
-
 plugins {
     kotlin("jvm")
     id("com.gradleup.shadow") version "8.3.6"
+    id("io.github.tiktok.knit.plugin") version "0.1.5"
     application
 }
-
-apply(plugin = "io.github.tiktok.knit.plugin")
 
 repositories {
     mavenCentral()

--- a/demo-jvm/build.gradle.kts
+++ b/demo-jvm/build.gradle.kts
@@ -1,3 +1,5 @@
+import tiktok.knit.plugin.KnitExtension
+
 plugins {
     kotlin("jvm")
     id("com.gradleup.shadow") version "8.3.6"
@@ -21,3 +23,9 @@ tasks.test {
 application {
     mainClass.set("knit.demo.MainKt")
 }
+
+extensions.getByType<KnitExtension>().apply {
+    dependencyTreeOutputPath.set("build/knit_dependency.json")
+}
+
+

--- a/knit-plugin/build.gradle.kts
+++ b/knit-plugin/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     kotlin("jvm")
     id("com.gradle.plugin-publish") version "1.1.0"
     id("insidePublish")
+    id("signing")
 }
 
 val projectGitUrl: String by project
@@ -31,4 +32,8 @@ dependencies {
     compileOnly("com.android.tools.build:gradle:$agpVersion")
     implementation(project(":knit-asm"))
     implementation("org.ow2.asm:asm-tree:$asmVersion")
+}
+
+signing {
+    isRequired = false
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,6 @@
 pluginManagement {
     repositories {
+    maven { url = uri("${rootDir}/build/artifactLocalPublish") }
         mavenLocal()
         mavenCentral()
         gradlePluginPortal()


### PR DESCRIPTION
Based on [PR #1 ](https://github.com/anikahandigol/knit/pull/1)

Added Dump extension of Knit to build.gradle.kts in demo-jvm folder. Compiling fat jar for demo-jvm generates JSON file containing the dependency tree of demo-jvm in demo-jvm/build/knit-dependency.json. Currently, this JSON file only updates after compiling the project's fat jar. 