### PR TITLE
Added functionality to optimistically log and update knit.json even if DI-related errors occur

### DIFF
--- a/demo-jvm/build.gradle.kts
+++ b/demo-jvm/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     kotlin("jvm")
     id("com.gradleup.shadow") version "8.3.6"
     id("application")
-    id("io.github.tiktok.knit.plugin") version "0.1.5-local"
+    id("io.github.tiktok.knit.plugin") version "0.1.5-local.2"
 }
 
 /**

--- a/demo-jvm/build.gradle.kts
+++ b/demo-jvm/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     kotlin("jvm")
     id("com.gradleup.shadow") version "8.3.6"
     id("application")
-    id("io.github.tiktok.knit.plugin") version "0.1.5-local.3"
+    id("io.github.tiktok.knit.plugin") version "0.1.5-local.4"
 }
 
 /**

--- a/demo-jvm/build.gradle.kts
+++ b/demo-jvm/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     kotlin("jvm")
     id("com.gradleup.shadow") version "8.3.6"
     id("application")
-    id("io.github.tiktok.knit.plugin") version "0.1.5-local.2"
+    id("io.github.tiktok.knit.plugin") version "0.1.5-local.3"
 }
 
 /**

--- a/demo-jvm/src/main/kotlin/knit/demo/Main.kt
+++ b/demo-jvm/src/main/kotlin/knit/demo/Main.kt
@@ -2,10 +2,11 @@ package knit.demo
 
 import knit.di
 
-
 class MemoryGitApplication {
     private val cli: SampleCli by di
-    fun start() = cli.start()
+    fun start() {
+        cli.start()
+    }
 }
 
 fun main() = MemoryGitApplication().start()

--- a/demo-jvm/src/main/kotlin/knit/demo/Main.kt
+++ b/demo-jvm/src/main/kotlin/knit/demo/Main.kt
@@ -4,7 +4,9 @@ import knit.di
 
 class MemoryGitApplication {
     private val cli: SampleCli by di
+    private val test: Test by di
     fun start() {
+        test.runTest()
         cli.start()
     }
 }

--- a/demo-jvm/src/main/kotlin/knit/demo/Test.kt
+++ b/demo-jvm/src/main/kotlin/knit/demo/Test.kt
@@ -6,11 +6,14 @@ import knit.Provides
 @Component
 @Provides
 class Test {
+    private val app: MemoryGitApplication by knit.di
     private val testValue: String = "default"
 
     fun runTest() {
         println("testing code")
         println("testing incremental nature")
+        // touch the app to ensure the DI edge is realized
+        if (testValue.isNotEmpty()) app.toString()
         return
     }
 }

--- a/demo-jvm/src/main/kotlin/knit/demo/Test.kt
+++ b/demo-jvm/src/main/kotlin/knit/demo/Test.kt
@@ -1,0 +1,16 @@
+package knit.demo
+
+import knit.Component
+import knit.Provides
+
+@Component
+@Provides
+class Test {
+    private val testValue: String = "default"
+
+    fun runTest() {
+        println("testing code")
+        println("testing incremental nature")
+        return
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,5 +30,5 @@ junitVersion=5.10.0
 GROUP=io.github.tiktok.knit
 localPublish=true
 remoteKnitVersion=0.1.3
-knitVersion=0.1.5-local
+knitVersion=0.1.5-local.2
 projectGitUrl=https://github.com/tiktok/knit

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,5 +30,5 @@ junitVersion=5.10.0
 GROUP=io.github.tiktok.knit
 localPublish=true
 remoteKnitVersion=0.1.3
-knitVersion=0.1.5-local.3
+knitVersion=0.1.5-local.4
 projectGitUrl=https://github.com/tiktok/knit

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,5 +30,5 @@ junitVersion=5.10.0
 GROUP=io.github.tiktok.knit
 localPublish=true
 remoteKnitVersion=0.1.3
-knitVersion=0.1.5-local.2
+knitVersion=0.1.5-local.3
 projectGitUrl=https://github.com/tiktok/knit

--- a/knit-asm/src/main/java/tiktok/knit/plugin/dump/Dumps.kt
+++ b/knit-asm/src/main/java/tiktok/knit/plugin/dump/Dumps.kt
@@ -65,6 +65,8 @@ data class ComponentDump(
 data class Status(
     val error: Boolean? = null,
     val optimistic: Boolean? = null,
+    val added: Boolean? = null,
+    val removed: Boolean? = null,
 )
 
 data class Delta(

--- a/knit-asm/src/main/java/tiktok/knit/plugin/dump/Dumps.kt
+++ b/knit-asm/src/main/java/tiktok/knit/plugin/dump/Dumps.kt
@@ -38,6 +38,10 @@ data class ComponentDump(
     val composite: Map<String, String>?,
     val injections: Map<String, InjectionDump>?,
     val providers: List<ProviderDump>?,
+    // Optional optimistic/error status metadata
+    val status: Status? = null,
+    // Optional per-component delta metadata
+    val delta: Delta? = null,
 ) {
     companion object : CanDump<BoundComponentClass, ComponentDump> {
         override fun dump(origin: BoundComponentClass): ComponentDump {
@@ -51,12 +55,29 @@ data class ComponentDump(
                 propAcc.printable() to dump
             }?.toMap()
             val providers = origin.provides.map { ProviderDump.dump(it) }
-            return ComponentDump(parent.orNull(), composite.orNull(), injections?.orNull(), providers.orNull())
+            return ComponentDump(parent.orNull(), composite.orNull(), injections?.orNull(), providers.orNull(), null, null)
         }
 
-        val default = ComponentDump(null, null, null, null)
+        val default = ComponentDump(null, null, null, null, null, null)
     }
 }
+
+data class Status(
+    val error: Boolean? = null,
+    val optimistic: Boolean? = null,
+)
+
+data class Delta(
+    val parentsAdded: List<String>? = null,
+    val parentsRemoved: List<String>? = null,
+    val compositeAdded: List<String>? = null,
+    val compositeRemoved: List<String>? = null,
+    val injectionsAddedKeys: List<String>? = null,
+    val injectionsRemovedKeys: List<String>? = null,
+    val injectionsUpdatedKeys: List<String>? = null,
+    val providersAdded: List<String>? = null,
+    val providersRemoved: List<String>? = null,
+)
 
 typealias InjectionWithOrigin = Pair<BoundComponentClass, Injection>
 

--- a/knit-plugin/build.gradle.kts
+++ b/knit-plugin/build.gradle.kts
@@ -31,4 +31,5 @@ dependencies {
     compileOnly("com.android.tools.build:gradle:$agpVersion")
     implementation(project(":knit-asm"))
     implementation("org.ow2.asm:asm-tree:$asmVersion")
+    implementation("com.google.code.gson:gson:2.8.9")
 }

--- a/knit-plugin/src/main/java/tiktok/knit/plugin/KnitGradlePlugin.kt
+++ b/knit-plugin/src/main/java/tiktok/knit/plugin/KnitGradlePlugin.kt
@@ -50,6 +50,8 @@ abstract class KnitGradlePlugin : Plugin<Project> {
         val dumpTask = tasks.register("knitDump", DumpTask::class.java)
         dumpTask.configure {
             it.group = GROUP
+            // Ensure classes are compiled before dumping
+            it.dependsOn(tasks.named("compileKotlin"))
             val ext = extensions.getByType(KnitExtension::class.java)
             it.dumpOutput.set(file(ext.dependencyTreeOutputPath))
         }

--- a/knit-plugin/src/main/java/tiktok/knit/plugin/KnitGradlePlugin.kt
+++ b/knit-plugin/src/main/java/tiktok/knit/plugin/KnitGradlePlugin.kt
@@ -45,6 +45,14 @@ abstract class KnitGradlePlugin : Plugin<Project> {
                 it.output.set(newOutputFile)
             }
         }
+
+        // Standalone dump task: scans compiled classes directly and writes JSON + delta log.
+        val dumpTask = tasks.register("knitDump", DumpTask::class.java)
+        dumpTask.configure {
+            it.group = GROUP
+            val ext = extensions.getByType(KnitExtension::class.java)
+            it.dumpOutput.set(file(ext.dependencyTreeOutputPath))
+        }
         return true
     }
 
@@ -65,6 +73,29 @@ abstract class KnitGradlePlugin : Plugin<Project> {
             val knitTask = KnitTask(
                 allJars, emptyList(), outputJarFile, true,
                 dumpOutput = dumpOutputFile,
+            )
+            knitTask.execute()
+        }
+    }
+
+    abstract class DumpTask : DefaultTask() {
+        @get:OutputFile
+        abstract val dumpOutput: RegularFileProperty
+
+        @TaskAction
+        fun taskAction() {
+            val project = project
+            // Default to Kotlin main classes directory
+            val classDir = project.layout.buildDirectory.dir("classes/kotlin/main").get().asFile
+            val tmpJar = project.layout.buildDirectory.file("tmp/knitDump/knit-dump.jar").get().asFile
+            tmpJar.parentFile.mkdirs()
+            val dumpFile = dumpOutput.get().asFile
+            val knitTask = KnitTask(
+                jarInputs = emptyList(),
+                dirInputs = listOf(classDir).filter { it.exists() },
+                outputJar = tmpJar,
+                useJrt = true,
+                dumpOutput = dumpFile,
             )
             knitTask.execute()
         }


### PR DESCRIPTION
Added:
- A `Test` class to more clearly test DI modification and circular dependency use cases
- New `knitDump` standalone task to ensure that logging is run even if the creation of the shadowJar fails
- Optimistic updating, generating changelog json files even if changes lead to DI-related errors

Improvements needed:
- More structured error handling for both errors (circular dependencies, etc.) and warnings (standalone dependencies)